### PR TITLE
Port direction ansi

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -245,7 +245,7 @@ fn parse_module_declaration_ansi(
                 .push(parse_module_declaration_parameter(p, syntax_tree)),
             RefNode::AnsiPortDeclaration(p) => {
                 let parsed_port: structures::SvPort =
-                    parse_module_declaration_port(p, syntax_tree, &prev_port.clone());
+                    parse_module_declaration_port_ansi(p, syntax_tree, &prev_port.clone());
                 ret.ports.push(parsed_port.clone());
                 prev_port = Some(parsed_port.clone());
             }
@@ -286,7 +286,7 @@ fn port_identifier(node: &sv_parser::AnsiPortDeclaration, syntax_tree: &SyntaxTr
     identifier(id, &syntax_tree).unwrap()
 }
 
-fn port_direction(node: &sv_parser::AnsiPortDeclaration) -> structures::SvPortDirection {
+fn port_direction_ansi(node: &sv_parser::AnsiPortDeclaration) -> structures::SvPortDirection {
     let dir = unwrap_node!(node, PortDirection);
     match dir {
         Some(RefNode::PortDirection(sv_parser::PortDirection::Inout(_))) => {
@@ -334,14 +334,14 @@ fn port_datatype(node: &sv_parser::AnsiPortDeclaration, syntax_tree: &SyntaxTree
     }
 }
 
-fn parse_module_declaration_port(
+fn parse_module_declaration_port_ansi(
     p: &sv_parser::AnsiPortDeclaration,
     syntax_tree: &SyntaxTree,
     _prev_port: &Option<structures::SvPort>,
 ) -> structures::SvPort {
     structures::SvPort {
         identifier: port_identifier(p, syntax_tree),
-        direction: port_direction(p),
+        direction: port_direction_ansi(p),
         datakind: port_datakind(p),
         datatype: port_datatype(p, syntax_tree),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -286,7 +286,7 @@ fn port_identifier(node: &sv_parser::AnsiPortDeclaration, syntax_tree: &SyntaxTr
     identifier(id, &syntax_tree).unwrap()
 }
 
-fn port_direction_ansi(node: &sv_parser::AnsiPortDeclaration) -> structures::SvPortDirection {
+fn port_direction_ansi(node: &sv_parser::AnsiPortDeclaration, prev_port: &Option<structures::SvPort>) -> structures::SvPortDirection {
     let dir = unwrap_node!(node, PortDirection);
     match dir {
         Some(RefNode::PortDirection(sv_parser::PortDirection::Inout(_))) => {
@@ -301,7 +301,10 @@ fn port_direction_ansi(node: &sv_parser::AnsiPortDeclaration) -> structures::SvP
         Some(RefNode::PortDirection(sv_parser::PortDirection::Ref(_))) => {
             structures::SvPortDirection::Ref
         }
-        _ => structures::SvPortDirection::IMPLICIT,
+        _ => match prev_port {
+            Some(_) => prev_port.clone().unwrap().direction,
+            None => structures::SvPortDirection::Inout,
+        },
     }
 }
 
@@ -337,11 +340,11 @@ fn port_datatype(node: &sv_parser::AnsiPortDeclaration, syntax_tree: &SyntaxTree
 fn parse_module_declaration_port_ansi(
     p: &sv_parser::AnsiPortDeclaration,
     syntax_tree: &SyntaxTree,
-    _prev_port: &Option<structures::SvPort>,
+    prev_port: &Option<structures::SvPort>,
 ) -> structures::SvPort {
     structures::SvPort {
         identifier: port_identifier(p, syntax_tree),
-        direction: port_direction_ansi(p),
+        direction: port_direction_ansi(p, prev_port),
         datakind: port_datakind(p),
         datatype: port_datatype(p, syntax_tree),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,14 +228,19 @@ fn parse_module_declaration_ansi(
         filepath: String::from(filepath),
     };
 
+    let mut prev_port: Option<structures::SvPort> = None;
+
     for node in m {
         match node {
             RefNode::ParameterDeclarationParam(p) => ret
                 .parameters
                 .push(parse_module_declaration_parameter(p, syntax_tree)),
-            RefNode::AnsiPortDeclaration(p) => ret
-                .ports
-                .push(parse_module_declaration_port(p, syntax_tree)),
+            RefNode::AnsiPortDeclaration(p) => {
+                let parsed_port: structures::SvPort =
+                    parse_module_declaration_port(p, syntax_tree, &prev_port.clone());
+                ret.ports.push(parsed_port.clone());
+                prev_port = Some(parsed_port.clone());
+            }
             _ => (),
         }
     }
@@ -324,6 +329,7 @@ fn port_datatype(node: &sv_parser::AnsiPortDeclaration, syntax_tree: &SyntaxTree
 fn parse_module_declaration_port(
     p: &sv_parser::AnsiPortDeclaration,
     syntax_tree: &SyntaxTree,
+    _prev_port: &Option<structures::SvPort>,
 ) -> structures::SvPort {
     structures::SvPort {
         identifier: port_identifier(p, syntax_tree),

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,11 @@ pub fn run_opt(opt: &Opt) -> Result<bool, Error> {
         let mut pass = true;
         match parse_sv(&path, &defines, &includes, opt.ignore_include, false) {
             Ok((syntax_tree, new_defines)) => {
-                sv_to_structure(&syntax_tree, &path.to_string_lossy().into_owned(), &mut svdata);
+                sv_to_structure(
+                    &syntax_tree,
+                    &path.to_string_lossy().into_owned(),
+                    &mut svdata,
+                );
                 defines = new_defines;
             }
             Err(_) => {
@@ -148,7 +152,11 @@ fn parse_filelist(
     Ok((filelist.files, filelist.incdirs, defines))
 }
 
-fn sv_to_structure(syntax_tree: &SyntaxTree, filepath: &str, svdata: &mut structures::SvData) -> () {
+fn sv_to_structure(
+    syntax_tree: &SyntaxTree,
+    filepath: &str,
+    svdata: &mut structures::SvData,
+) -> () {
     for event in syntax_tree.into_iter().event() {
         let enter_not_leave = match event {
             NodeEvent::Enter(_) => true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -286,7 +286,10 @@ fn port_identifier(node: &sv_parser::AnsiPortDeclaration, syntax_tree: &SyntaxTr
     identifier(id, &syntax_tree).unwrap()
 }
 
-fn port_direction_ansi(node: &sv_parser::AnsiPortDeclaration, prev_port: &Option<structures::SvPort>) -> structures::SvPortDirection {
+fn port_direction_ansi(
+    node: &sv_parser::AnsiPortDeclaration,
+    prev_port: &Option<structures::SvPort>,
+) -> structures::SvPortDirection {
     let dir = unwrap_node!(node, PortDirection);
     match dir {
         Some(RefNode::PortDirection(sv_parser::PortDirection::Inout(_))) => {

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -12,6 +12,7 @@ pub struct SvModuleDeclaration {
     pub identifier: String,
     pub parameters: Vec<SvParameter>,
     pub ports: Vec<SvPort>,
+    pub filepath: String,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -63,6 +64,7 @@ impl fmt::Display for SvModuleDeclaration {
     fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
         writeln!(f, "Module:")?;
         writeln!(f, "  Identifier: {}", self.identifier)?;
+        writeln!(f, "  Filepath: {}", self.filepath)?;
 
         for port in self.ports.clone() {
             write!(f, "{}", port)?;


### PR DESCRIPTION
Based on module-inheritance branch for enabling the retrieval of the direction declared in the previous port declaration if not explicitly stated in the current port declaration. If no previous port is available, the default value is chosen.