### PR TITLE
Port nettype ansi

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         rust: [stable]
     runs-on: ${{ matrix.os }}
     steps:

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,7 +336,7 @@ fn port_datatype_ansi(
     node: &sv_parser::AnsiPortDeclaration,
     syntax_tree: &SyntaxTree,
 ) -> structures::SvDataType {
-    let dir = unwrap_node!(
+    let datatype = unwrap_node!(
         node,
         IntegerVectorType,
         IntegerAtomType,
@@ -344,7 +344,7 @@ fn port_datatype_ansi(
         ClassType,
         TypeReference
     );
-    match dir {
+    match datatype {
         Some(RefNode::IntegerVectorType(sv_parser::IntegerVectorType::Logic(_))) => {
             structures::SvDataType::Logic
         }
@@ -406,8 +406,8 @@ fn port_nettype_ansi(
     direction: &structures::SvPortDirection,
     syntax_tree: &SyntaxTree,
 ) -> Option<structures::SvNetType> {
-    let dir = unwrap_node!(m, AnsiPortDeclarationVariable, AnsiPortDeclarationNet);
-    match dir {
+    let nettype = unwrap_node!(m, AnsiPortDeclarationVariable, AnsiPortDeclarationNet);
+    match nettype {
         Some(RefNode::AnsiPortDeclarationVariable(_)) => return None, // "Var" token was found
 
         Some(RefNode::AnsiPortDeclarationNet(x)) => {
@@ -498,8 +498,8 @@ fn port_nettype_ansi(
 }
 
 fn port_signedness_ansi(m: &sv_parser::AnsiPortDeclaration) -> structures::SvSignedness {
-    let dir = unwrap_node!(m, Signing);
-    match dir {
+    let signedness = unwrap_node!(m, Signing);
+    match signedness {
         Some(RefNode::Signing(sv_parser::Signing::Signed(_))) => structures::SvSignedness::Signed,
         Some(RefNode::Signing(sv_parser::Signing::Unsigned(_))) => {
             structures::SvSignedness::Unsigned
@@ -509,9 +509,9 @@ fn port_signedness_ansi(m: &sv_parser::AnsiPortDeclaration) -> structures::SvSig
 }
 
 fn port_check_inheritance_ansi(m: &sv_parser::AnsiPortDeclaration) -> bool {
-    let dir = unwrap_node!(m, DataType, Signing, NetType, VarDataType, PortDirection);
+    let datatype = unwrap_node!(m, DataType, Signing, NetType, VarDataType, PortDirection);
 
-    match dir {
+    match datatype {
         Some(_) => false,
         _ => true,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -405,10 +405,10 @@ fn port_nettype_ansi(
     m: &sv_parser::AnsiPortDeclaration,
     direction: &structures::SvPortDirection,
     syntax_tree: &SyntaxTree,
-) -> structures::SvNetType {
+) -> Option<structures::SvNetType> {
     let dir = unwrap_node!(m, AnsiPortDeclarationVariable, AnsiPortDeclarationNet);
     match dir {
-        Some(RefNode::AnsiPortDeclarationVariable(_)) => return structures::SvNetType::NA, // "Var" token was found
+        Some(RefNode::AnsiPortDeclarationVariable(_)) => return None, // "Var" token was found
 
         Some(RefNode::AnsiPortDeclarationNet(x)) => {
             let dir = unwrap_node!(x, NetType);
@@ -416,45 +416,45 @@ fn port_nettype_ansi(
             match dir {
                 // "Var" token was not found
                 Some(RefNode::NetType(sv_parser::NetType::Supply0(_))) => {
-                    return structures::SvNetType::Supply0
+                    return Some(structures::SvNetType::Supply0)
                 }
                 Some(RefNode::NetType(sv_parser::NetType::Supply1(_))) => {
-                    return structures::SvNetType::Supply1
+                    return Some(structures::SvNetType::Supply1)
                 }
                 Some(RefNode::NetType(sv_parser::NetType::Triand(_))) => {
-                    return structures::SvNetType::Triand
+                    return Some(structures::SvNetType::Triand)
                 }
                 Some(RefNode::NetType(sv_parser::NetType::Trior(_))) => {
-                    return structures::SvNetType::Trior
+                    return Some(structures::SvNetType::Trior)
                 }
                 Some(RefNode::NetType(sv_parser::NetType::Trireg(_))) => {
-                    return structures::SvNetType::Trireg
+                    return Some(structures::SvNetType::Trireg)
                 }
                 Some(RefNode::NetType(sv_parser::NetType::Tri0(_))) => {
-                    return structures::SvNetType::Tri0
+                    return Some(structures::SvNetType::Tri0)
                 }
                 Some(RefNode::NetType(sv_parser::NetType::Tri1(_))) => {
-                    return structures::SvNetType::Tri1
+                    return Some(structures::SvNetType::Tri1)
                 }
                 Some(RefNode::NetType(sv_parser::NetType::Tri(_))) => {
-                    return structures::SvNetType::Tri
+                    return Some(structures::SvNetType::Tri)
                 }
                 Some(RefNode::NetType(sv_parser::NetType::Uwire(_))) => {
-                    return structures::SvNetType::Uwire
+                    return Some(structures::SvNetType::Uwire)
                 }
                 Some(RefNode::NetType(sv_parser::NetType::Wire(_))) => {
-                    return structures::SvNetType::Wire
+                    return Some(structures::SvNetType::Wire)
                 }
                 Some(RefNode::NetType(sv_parser::NetType::Wand(_))) => {
-                    return structures::SvNetType::Wand
+                    return Some(structures::SvNetType::Wand)
                 }
                 Some(RefNode::NetType(sv_parser::NetType::Wor(_))) => {
-                    return structures::SvNetType::Wor
+                    return Some(structures::SvNetType::Wor)
                 }
 
                 _ => match direction {
                     structures::SvPortDirection::Inout | structures::SvPortDirection::Input => {
-                        return structures::SvNetType::Wire;
+                        return Some(structures::SvNetType::Wire);
                     }
                     structures::SvPortDirection::Output => {
                         match unwrap_node!(
@@ -465,12 +465,12 @@ fn port_nettype_ansi(
                             ClassType,
                             TypeReference
                         ) {
-                            Some(_) => return structures::SvNetType::NA,
+                            Some(_) => return None,
                             _ => match unwrap_node!(m, DataType) {
                                 Some(x) => match keyword(x, syntax_tree) {
                                     Some(x) => {
                                         if x == "string" {
-                                            return structures::SvNetType::NA;
+                                            return None;
                                         } else {
                                             println!("{}", x);
                                             unreachable!();
@@ -479,13 +479,13 @@ fn port_nettype_ansi(
 
                                     _ => unreachable!(),
                                 },
-                                _ => return structures::SvNetType::Wire,
+                                _ => return Some(structures::SvNetType::Wire),
                             },
                         }
                     }
 
                     structures::SvPortDirection::Ref => {
-                        return structures::SvNetType::NA;
+                        return None;
                     }
 
                     _ => unreachable!(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -530,6 +530,7 @@ fn parse_module_declaration_port_ansi(
         ret = structures::SvPort {
             identifier: port_identifier(p, syntax_tree),
             direction: port_direction_ansi(p, prev_port),
+            nettype: port_nettype_ansi(p, &port_direction_ansi(p, prev_port), syntax_tree),
             datakind: port_datakind(p),
             datatype: port_datatype_ansi(p, syntax_tree),
             signedness: port_signedness_ansi(p),
@@ -538,6 +539,7 @@ fn parse_module_declaration_port_ansi(
         ret = structures::SvPort {
             identifier: port_identifier(p, syntax_tree),
             direction: prev_port.clone().unwrap().direction,
+            nettype: prev_port.clone().unwrap().nettype,
             datakind: prev_port.clone().unwrap().datakind,
             datatype: prev_port.clone().unwrap().datatype,
             signedness: prev_port.clone().unwrap().signedness,

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,6 +325,7 @@ fn port_direction_ansi(
 }
 
 fn port_datakind(node: &sv_parser::AnsiPortDeclaration) -> structures::SvPortDatakind {
+    
     match node {
         sv_parser::AnsiPortDeclaration::Net(_) => structures::SvPortDatakind::Net,
         sv_parser::AnsiPortDeclaration::Variable(_) => structures::SvPortDatakind::Variable,

--- a/src/main.rs
+++ b/src/main.rs
@@ -466,25 +466,21 @@ fn port_nettype_ansi(
                             TypeReference
                         ) {
                             Some(_) => return structures::SvNetType::NA,
-                            _ => {
-                                match unwrap_node!(m, DataType) {
+                            _ => match unwrap_node!(m, DataType) {
+                                Some(x) => match keyword(x, syntax_tree) {
                                     Some(x) => {
-                                        match keyword(x, syntax_tree) {
-                                            Some(x) => {
-                                                if x == "string" {
-                                                    return structures::SvNetType::NA;
-                                                } else {
-                                                    println!("{}", x);
-                                                    unreachable!();
-                                                }
-                                            }
-                    
-                                            _ => unreachable!(),
+                                        if x == "string" {
+                                            return structures::SvNetType::NA;
+                                        } else {
+                                            println!("{}", x);
+                                            unreachable!();
                                         }
                                     }
-                                    _ => return structures::SvNetType::Wire,
-                                }
-                            }
+
+                                    _ => unreachable!(),
+                                },
+                                _ => return structures::SvNetType::Wire,
+                            },
                         }
                     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,7 +325,6 @@ fn port_direction_ansi(
 }
 
 fn port_datakind(node: &sv_parser::AnsiPortDeclaration) -> structures::SvPortDatakind {
-    
     match node {
         sv_parser::AnsiPortDeclaration::Net(_) => structures::SvPortDatakind::Net,
         sv_parser::AnsiPortDeclaration::Variable(_) => structures::SvPortDatakind::Variable,

--- a/src/main.rs
+++ b/src/main.rs
@@ -404,6 +404,7 @@ fn port_datatype_ansi(
 fn port_nettype_ansi(
     m: &sv_parser::AnsiPortDeclaration,
     direction: &structures::SvPortDirection,
+    syntax_tree: &SyntaxTree,
 ) -> structures::SvNetType {
     let dir = unwrap_node!(m, AnsiPortDeclarationVariable, AnsiPortDeclarationNet);
     match dir {
@@ -465,7 +466,25 @@ fn port_nettype_ansi(
                             TypeReference
                         ) {
                             Some(_) => return structures::SvNetType::NA,
-                            _ => return structures::SvNetType::Wire,
+                            _ => {
+                                match unwrap_node!(m, DataType) {
+                                    Some(x) => {
+                                        match keyword(x, syntax_tree) {
+                                            Some(x) => {
+                                                if x == "string" {
+                                                    return structures::SvNetType::NA;
+                                                } else {
+                                                    println!("{}", x);
+                                                    unreachable!();
+                                                }
+                                            }
+                    
+                                            _ => unreachable!(),
+                                        }
+                                    }
+                                    _ => return structures::SvNetType::Wire,
+                                }
+                            }
                         }
                     }
 
@@ -501,7 +520,7 @@ fn parse_module_declaration_port_ansi(
     structures::SvPort {
         identifier: port_identifier(p, syntax_tree),
         direction: port_direction_ansi(p, prev_port),
-        nettype: port_nettype_ansi(p, &port_direction_ansi(p, prev_port)),
+        nettype: port_nettype_ansi(p, &port_direction_ansi(p, prev_port), syntax_tree),
         datakind: port_datakind(p),
         datatype: port_datatype_ansi(p, syntax_tree),
         signedness: port_signedness_ansi(p),

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -87,7 +87,6 @@ pub enum SvNetType {
     Tri1,
     Supply0,
     Supply1,
-    NA,
     IMPLICIT,
 }
 
@@ -97,7 +96,7 @@ pub struct SvPort {
     pub direction: SvPortDirection,
     pub datakind: SvPortDatakind,
     pub datatype: SvDataType,
-    pub nettype: SvNetType,
+    pub nettype: Option<SvNetType>,
     pub signedness: SvSignedness,
 }
 
@@ -132,7 +131,14 @@ impl fmt::Display for SvPort {
         writeln!(f, "    Direction: {:?}", self.direction)?;
         writeln!(f, "    DataKind: {:?}", self.datakind)?;
         writeln!(f, "    DataType: {:?}", self.datatype)?;
-        writeln!(f, "    NetType: {:?}", self.nettype)?;
+        match self.nettype.clone() {
+            None => {
+                writeln!(f, "    NetType: None")?;
+            },
+            Some(x) => {
+                writeln!(f, "    NetType: {:?}", x)?;
+            },
+        }
         writeln!(f, "    Signedness: {:?}", self.signedness)
     }
 }

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -134,10 +134,10 @@ impl fmt::Display for SvPort {
         match self.nettype.clone() {
             None => {
                 writeln!(f, "    NetType: None")?;
-            },
+            }
             Some(x) => {
                 writeln!(f, "    NetType: {:?}", x)?;
-            },
+            }
         }
         writeln!(f, "    Signedness: {:?}", self.signedness)
     }

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -74,11 +74,30 @@ pub enum SvDataType {
 }
 
 #[derive(Debug, Serialize, Clone)]
+pub enum SvNetType {
+    Wire,
+    Uwire,
+    Tri,
+    Wor,
+    Wand,
+    Triand,
+    Trior,
+    Trireg,
+    Tri0,
+    Tri1,
+    Supply0,
+    Supply1,
+    NA,
+    IMPLICIT,
+}
+
+#[derive(Debug, Serialize, Clone)]
 pub struct SvPort {
     pub identifier: String,
     pub direction: SvPortDirection,
     pub datakind: SvPortDatakind,
     pub datatype: SvDataType,
+    pub nettype: SvNetType,
     pub signedness: SvSignedness,
 }
 
@@ -113,6 +132,7 @@ impl fmt::Display for SvPort {
         writeln!(f, "    Direction: {:?}", self.direction)?;
         writeln!(f, "    DataKind: {:?}", self.datakind)?;
         writeln!(f, "    DataType: {:?}", self.datatype)?;
+        writeln!(f, "    NetType: {:?}", self.nettype)?;
         writeln!(f, "    Signedness: {:?}", self.signedness)
     }
 }


### PR DESCRIPTION
Based on SHA: fd57316160c9141eedc623272c0e8d3fdcbcf2e4 Adds SvNetType as an enum in structures as well as the function "port_nettype_ansi" for matching with the correct nettype found in the syntax tree (if any). If no explicit type is found then the LRM rules are followed. Finally nettype added to the display trait among the other port data.