### PR TITLE
Port datakind ansi

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         rust: [stable]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest]
         rust: [stable]
     runs-on: ${{ matrix.os }}
     steps:

--- a/src/main.rs
+++ b/src/main.rs
@@ -324,9 +324,7 @@ fn port_direction_ansi(
     }
 }
 
-fn port_datakind_ansi(
-    nettype: &structures::SvNetType,
-) -> structures::SvDataKind {
+fn port_datakind_ansi(nettype: &structures::SvNetType) -> structures::SvDataKind {
     match nettype {
         structures::SvNetType::NA => structures::SvDataKind::Variable,
 
@@ -519,7 +517,11 @@ fn parse_module_declaration_port_ansi(
         identifier: port_identifier(p, syntax_tree),
         direction: port_direction_ansi(p, prev_port),
         nettype: port_nettype_ansi(p, &port_direction_ansi(p, prev_port), syntax_tree),
-        datakind: port_datakind_ansi(&port_nettype_ansi(p, &port_direction_ansi(p, prev_port), syntax_tree)),
+        datakind: port_datakind_ansi(&port_nettype_ansi(
+            p,
+            &port_direction_ansi(p, prev_port),
+            syntax_tree,
+        )),
         datatype: port_datatype_ansi(p, syntax_tree),
         signedness: port_signedness_ansi(p),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -466,25 +466,21 @@ fn port_nettype_ansi(
                             TypeReference
                         ) {
                             Some(_) => return structures::SvNetType::NA,
-                            _ => {
-                                match unwrap_node!(m, DataType) {
+                            _ => match unwrap_node!(m, DataType) {
+                                Some(x) => match keyword(x, syntax_tree) {
                                     Some(x) => {
-                                        match keyword(x, syntax_tree) {
-                                            Some(x) => {
-                                                if x == "string" {
-                                                    return structures::SvNetType::NA;
-                                                } else {
-                                                    println!("{}", x);
-                                                    unreachable!();
-                                                }
-                                            }
-                    
-                                            _ => unreachable!(),
+                                        if x == "string" {
+                                            return structures::SvNetType::NA;
+                                        } else {
+                                            println!("{}", x);
+                                            unreachable!();
                                         }
                                     }
-                                    _ => return structures::SvNetType::Wire,
-                                }
-                            }
+
+                                    _ => unreachable!(),
+                                },
+                                _ => return structures::SvNetType::Wire,
+                            },
                         }
                     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -324,11 +324,11 @@ fn port_direction_ansi(
     }
 }
 
-fn port_datakind_ansi(nettype: &structures::SvNetType) -> structures::SvDataKind {
+fn port_datakind_ansi(nettype: &Option<structures::SvNetType>) -> structures::SvDataKind {
     match nettype {
-        structures::SvNetType::NA => structures::SvDataKind::Variable,
+        None => structures::SvDataKind::Variable,
 
-        _ => structures::SvDataKind::Net,
+        Some(_) => structures::SvDataKind::Net,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -324,11 +324,13 @@ fn port_direction_ansi(
     }
 }
 
-fn port_datakind(node: &sv_parser::AnsiPortDeclaration) -> structures::SvDataKind {
-    match node {
-        sv_parser::AnsiPortDeclaration::Net(_) => structures::SvDataKind::Net,
-        sv_parser::AnsiPortDeclaration::Variable(_) => structures::SvDataKind::Variable,
-        sv_parser::AnsiPortDeclaration::Paren(_) => structures::SvDataKind::IMPLICIT,
+fn port_datakind_ansi(
+    nettype: &structures::SvNetType,
+) -> structures::SvDataKind {
+    match nettype {
+        structures::SvNetType::NA => structures::SvDataKind::Variable,
+
+        _ => structures::SvDataKind::Net,
     }
 }
 
@@ -517,7 +519,7 @@ fn parse_module_declaration_port_ansi(
         identifier: port_identifier(p, syntax_tree),
         direction: port_direction_ansi(p, prev_port),
         nettype: port_nettype_ansi(p, &port_direction_ansi(p, prev_port), syntax_tree),
-        datakind: port_datakind(p),
+        datakind: port_datakind_ansi(&port_nettype_ansi(p, &port_direction_ansi(p, prev_port), syntax_tree)),
         datatype: port_datatype_ansi(p, syntax_tree),
         signedness: port_signedness_ansi(p),
     }

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -36,7 +36,7 @@ pub enum SvPortDirection {
 }
 
 #[derive(Debug, Serialize, Clone)]
-pub enum SvPortDatakind {
+pub enum SvDataKind {
     Net,
     Variable,
     IMPLICIT,
@@ -95,7 +95,7 @@ pub enum SvNetType {
 pub struct SvPort {
     pub identifier: String,
     pub direction: SvPortDirection,
-    pub datakind: SvPortDatakind,
+    pub datakind: SvDataKind,
     pub datatype: SvDataType,
     pub nettype: SvNetType,
     pub signedness: SvSignedness,


### PR DESCRIPTION
Based on the port-nettype-ansi branch. Updates definition such that the function is based on the output obtained by the "port_nettype_ansi" function. Moreover updates the names of the enum and the corresponding function in main for ensuring symmetry and differentiation between the functions used by ansi and nonansi declarations types.