### PR TITLE
Full port inheritance

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -426,7 +426,6 @@ fn parse_module_declaration_port_ansi(
     syntax_tree: &SyntaxTree,
     prev_port: &Option<structures::SvPort>,
 ) -> structures::SvPort {
-
     let inherit = port_check_inheritance_ansi(p);
     let ret: structures::SvPort;
 
@@ -438,9 +437,7 @@ fn parse_module_declaration_port_ansi(
             datatype: port_datatype_ansi(p, syntax_tree),
             signedness: port_signedness_ansi(p),
         }
-    }  
-    
-    else {
+    } else {
         ret = structures::SvPort {
             identifier: port_identifier(p, syntax_tree),
             direction: prev_port.clone().unwrap().direction,

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,18 +412,45 @@ fn port_signedness_ansi(m: &sv_parser::AnsiPortDeclaration) -> structures::SvSig
     }
 }
 
+fn port_check_inheritance_ansi(m: &sv_parser::AnsiPortDeclaration) -> bool {
+    let dir = unwrap_node!(m, DataType, Signing, NetType, VarDataType, PortDirection);
+
+    match dir {
+        Some(_) => false,
+        _ => true,
+    }
+}
+
 fn parse_module_declaration_port_ansi(
     p: &sv_parser::AnsiPortDeclaration,
     syntax_tree: &SyntaxTree,
     prev_port: &Option<structures::SvPort>,
 ) -> structures::SvPort {
-    structures::SvPort {
-        identifier: port_identifier(p, syntax_tree),
-        direction: port_direction_ansi(p, prev_port),
-        datakind: port_datakind(p),
-        datatype: port_datatype_ansi(p, syntax_tree),
-        signedness: port_signedness_ansi(p),
+
+    let inherit = port_check_inheritance_ansi(p);
+    let ret: structures::SvPort;
+
+    if inherit == false {
+        ret = structures::SvPort {
+            identifier: port_identifier(p, syntax_tree),
+            direction: port_direction_ansi(p, prev_port),
+            datakind: port_datakind(p),
+            datatype: port_datatype_ansi(p, syntax_tree),
+            signedness: port_signedness_ansi(p),
+        }
+    }  
+    
+    else {
+        ret = structures::SvPort {
+            identifier: port_identifier(p, syntax_tree),
+            direction: prev_port.clone().unwrap().direction,
+            datakind: prev_port.clone().unwrap().datakind,
+            datatype: prev_port.clone().unwrap().datatype,
+            signedness: prev_port.clone().unwrap().signedness,
+        };
     }
+
+    return ret;
 }
 
 /*


### PR DESCRIPTION
Based on SHA: fd57316160c9141eedc623272c0e8d3fdcbcf2e4 Adds the following implementation:
Do not inherit signedness, data_type, data_kind and direction from last port if an explicit declaration is found for any of these. Otherwise inherit them.