### PR TITLE
Remove unused IMPLICIT members.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -487,8 +487,6 @@ fn port_nettype_ansi(
                     structures::SvPortDirection::Ref => {
                         return None;
                     }
-
-                    _ => unreachable!(),
                 },
             }
         }

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -32,21 +32,18 @@ pub enum SvPortDirection {
     Input,
     Output,
     Ref,
-    IMPLICIT,
 }
 
 #[derive(Debug, Serialize, Clone)]
 pub enum SvDataKind {
     Net,
     Variable,
-    IMPLICIT,
 }
 
 #[derive(Debug, Serialize, Clone)]
 pub enum SvSignedness {
     Signed,
     Unsigned,
-    IMPLICIT,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -70,7 +67,6 @@ pub enum SvDataType {
     Class,
     TypeRef,
     String,
-    IMPLICIT,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -87,7 +83,6 @@ pub enum SvNetType {
     Tri1,
     Supply0,
     Supply1,
-    IMPLICIT,
 }
 
 #[derive(Debug, Serialize, Clone)]


### PR DESCRIPTION
@vasilissoti Is it safe to remove IMPLICIT members?
I think it's okay since you're using `prev_port`.