### PR TITLE
tidyTest Minor cleanup.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -20,13 +20,13 @@ fn main() {
     // Output 'test.rs'
     // -------------------------------------------------------------------------------------------------
 
-    let out_test = Path::new(&out_dir).join("tests.rs");
-    let mut out_test = File::create(&out_test).unwrap();
+    let t = Path::new(&out_dir).join("tests.rs");
+    let mut t = File::create(&t).unwrap();
 
     for file_name in &entries {
-        let _ = write!(out_test, "#[test]\n");
-        let _ = write!(out_test, "fn test_{}() {{\n", file_name);
-        let _ = write!(out_test, "    tests(\"{}\");\n", file_name);
-        let _ = writeln!(out_test, "}}\n");
+        write!(t, "#[test]\n").unwrap();
+        write!(t, "fn test_{}() {{\n", file_name).unwrap();
+        write!(t, "    check_against_reference_outputs(\"{}\");\n", file_name).unwrap();
+        write!(t, "}}\n").unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -508,7 +508,7 @@ mod tests {
     use std::fs::File;
     use std::io::{BufReader, BufWriter, Write};
 
-    fn tests(name: &str) {
+    fn check_against_reference_outputs(name: &str) {
         let out_dir = env::var("OUT_DIR").unwrap();
 
         let sv_path = format!("testcases/sv/{}.sv", name);
@@ -516,37 +516,37 @@ mod tests {
         let opt = Opt::parse_from(args.iter());
         let svdata = run_opt(&opt).unwrap();
 
-        let expected_path = format!("testcases/json/{}.json", name);
-        let expected_file = File::open(expected_path).unwrap();
-        let expected_file = BufReader::new(expected_file);
-        let expected_json_value: serde_json::Value =
-            serde_json::from_reader(expected_file).unwrap();
+        let e = format!("testcases/json/{}.json", name);
+        let e = File::open(e).unwrap();
+        let e = BufReader::new(e);
+        let expected_json_value: serde_json::Value = serde_json::from_reader(e).unwrap();
 
-        let actual_string: String = serde_json::to_string_pretty(&svdata.clone().unwrap()).unwrap();
-        let actual_json_value: serde_json::Value = serde_json::from_str(&actual_string).unwrap();
+        let s: String = serde_json::to_string_pretty(&svdata.clone().unwrap()).unwrap();
+        let actual_json_value: serde_json::Value = serde_json::from_str(&s).unwrap();
 
-        let actual_path = Path::new(&out_dir).join(format!("testcases/json/{}.json", name));
+        // Write actual JSON to file for manual inspection.
         fs::create_dir_all(Path::new(&out_dir).join("testcases/json")).unwrap();
-        let actual_file = File::create(actual_path);
-        let mut actual_file = BufWriter::new(actual_file.unwrap());
-        _ = write!(actual_file, "{}", actual_string);
+        let a = Path::new(&out_dir).join(format!("testcases/json/{}.json", name));
+        let a = File::create(a);
+        let mut a = BufWriter::new(a.unwrap());
+        write!(a, "{}", s).unwrap();
 
         assert_eq!(expected_json_value, actual_json_value);
 
-        let expected_path = format!("testcases/yaml/{}.yaml", name);
-        let expected_file = File::open(expected_path).unwrap();
-        let expected_file = BufReader::new(expected_file);
-        let expected_yaml_value: serde_yaml::Value =
-            serde_yaml::from_reader(expected_file).unwrap();
+        let e = format!("testcases/yaml/{}.yaml", name);
+        let e = File::open(e).unwrap();
+        let e = BufReader::new(e);
+        let expected_yaml_value: serde_yaml::Value = serde_yaml::from_reader(e).unwrap();
 
-        let actual_string: String = serde_yaml::to_string(&svdata.clone().unwrap()).unwrap();
-        let actual_yaml_value: serde_yaml::Value = serde_yaml::from_str(&actual_string).unwrap();
+        let s: String = serde_yaml::to_string(&svdata.clone().unwrap()).unwrap();
+        let actual_yaml_value: serde_yaml::Value = serde_yaml::from_str(&s).unwrap();
 
-        let actual_path = Path::new(&out_dir).join(format!("testcases/yaml/{}.yaml", name));
+        // Write actual YAML to file for manual inspection.
         fs::create_dir_all(Path::new(&out_dir).join("testcases/yaml")).unwrap();
-        let actual_file = File::create(actual_path);
-        let mut actual_file = BufWriter::new(actual_file.unwrap());
-        _ = write!(actual_file, "{}", actual_string);
+        let a = Path::new(&out_dir).join(format!("testcases/yaml/{}.yaml", name));
+        let a = File::create(a);
+        let mut a = BufWriter::new(a.unwrap());
+        write!(a, "{}", s).unwrap();
 
         assert_eq!(expected_yaml_value, actual_yaml_value);
     }


### PR DESCRIPTION
- Use `write!(...).unwrap();` instead of `let _ = write!(...);` to panic
  if the write cannot be performed.
- Rename `tests` to `check_against_reference_outputs` so that it's easier
  to read/grep because lots of things are called test.
- Use single-char variable names for ones which are reused/temporary.
  Less noise, shorter lines, clear differentiation from "important" ones.