### PR TITLE
(bugfix-inheritance): Fixing inheritance detected in first port

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -455,12 +455,18 @@ fn port_signedness_ansi(m: &sv_parser::AnsiPortDeclaration) -> SvSignedness {
     }
 }
 
-fn port_check_inheritance_ansi(m: &sv_parser::AnsiPortDeclaration) -> bool {
+fn port_check_inheritance_ansi(
+    m: &sv_parser::AnsiPortDeclaration,
+    prev_port: &Option<SvPort>,
+) -> bool {
     let datatype = unwrap_node!(m, DataType, Signing, NetType, VarDataType, PortDirection);
 
-    match datatype {
-        Some(_) => false,
-        _ => true,
+    match prev_port {
+        Some(_) => match datatype {
+            Some(_) => false,
+            _ => true,
+        },
+        None => false,
     }
 }
 
@@ -469,7 +475,7 @@ fn parse_module_declaration_port_ansi(
     syntax_tree: &SyntaxTree,
     prev_port: &Option<SvPort>,
 ) -> SvPort {
-    let inherit = port_check_inheritance_ansi(p);
+    let inherit = port_check_inheritance_ansi(p, prev_port);
     let ret: SvPort;
 
     if inherit == false {

--- a/testcases/display/tst3.txt
+++ b/testcases/display/tst3.txt
@@ -1,0 +1,11 @@
+Module:
+  Identifier: Koo
+  Filepath: testcases/sv/tst3.sv
+  Port: 
+    Identifier: x
+    Direction: Inout
+    DataKind: Net
+    DataType: Logic
+    NetType: Wire
+    Signedness: Unsigned
+

--- a/testcases/json/tst3.json
+++ b/testcases/json/tst3.json
@@ -1,0 +1,20 @@
+{
+    "modules": [
+      {
+        "identifier": "Koo",
+        "parameters": [],
+        "ports": [
+          {
+            "identifier": "x",
+            "direction": "Inout",
+            "datakind": "Net",
+            "datatype": "Logic",
+            "nettype": "Wire",
+            "signedness": "Unsigned"
+          }
+        ],
+        "filepath": "testcases/sv/tst3.sv"
+      }
+    ],
+    "packages": []
+  }

--- a/testcases/sv/tst3.sv
+++ b/testcases/sv/tst3.sv
@@ -1,0 +1,4 @@
+module Koo
+( [5:0] x
+);
+endmodule

--- a/testcases/yaml/tst3.yaml
+++ b/testcases/yaml/tst3.yaml
@@ -1,0 +1,13 @@
+---
+modules:
+  - identifier: Koo
+    parameters: []
+    ports:
+      - identifier: x
+        direction: Inout
+        datakind: Net
+        datatype: Logic
+        nettype: Wire
+        signedness: Unsigned
+    filepath: testcases/sv/tst3.sv
+packages: []


### PR DESCRIPTION
Fixing error that occurred in cases that the need of inheritance was detected for the very first port.