### PR TITLE
(bugfix-signedness): Changing default signedness for integers & placing none where relevant

### DIFF
--- a/src/sv_port.rs
+++ b/src/sv_port.rs
@@ -209,7 +209,7 @@ fn port_signedness_ansi(
     datatype: &SvDataType,
 ) -> Option<SvSignedness> {
     match datatype {
-        SvDataType::Class => None,
+        SvDataType::Class | SvDataType::String | SvDataType::Real => None,
         _ => {
             let signedness = unwrap_node!(m, Signing);
             match signedness {

--- a/src/sv_port.rs
+++ b/src/sv_port.rs
@@ -222,7 +222,14 @@ fn port_signedness_ansi(
                 _ => (),
             }
 
-            Some(SvSignedness::Unsigned)
+            match datatype {
+                SvDataType::Shortint
+                | SvDataType::Int
+                | SvDataType::Longint
+                | SvDataType::Byte
+                | SvDataType::Integer => Some(SvSignedness::Signed),
+                _ => Some(SvSignedness::Unsigned),
+            }
         }
     }
 }

--- a/testcases/display/ansi_port_inout_net_unsigned.txt
+++ b/testcases/display/ansi_port_inout_net_unsigned.txt
@@ -41,7 +41,7 @@ Module:
     DataType: Int
     ClassIdentifier: None
     NetType: Wire
-    Signedness: Unsigned
+    Signedness: Signed
     PackedDimensions: []
     UnpackedDimensions: []
 

--- a/testcases/display/ansi_port_inout_net_unsigned.txt
+++ b/testcases/display/ansi_port_inout_net_unsigned.txt
@@ -74,7 +74,7 @@ Module:
     DataType: String
     ClassIdentifier: None
     NetType: Wire
-    Signedness: Unsigned
+    Signedness: None
     PackedDimensions: []
     UnpackedDimensions: []
 

--- a/testcases/display/ansi_port_input_net_unsigned.txt
+++ b/testcases/display/ansi_port_input_net_unsigned.txt
@@ -63,7 +63,7 @@ Module:
     DataType: String
     ClassIdentifier: None
     NetType: Wire
-    Signedness: Unsigned
+    Signedness: None
     PackedDimensions: []
     UnpackedDimensions: []
 

--- a/testcases/display/ansi_port_input_var_unsigned.txt
+++ b/testcases/display/ansi_port_input_var_unsigned.txt
@@ -63,7 +63,7 @@ Module:
     DataType: String
     ClassIdentifier: None
     NetType: None
-    Signedness: Unsigned
+    Signedness: None
     PackedDimensions: []
     UnpackedDimensions: []
 

--- a/testcases/display/ansi_port_output_net_unsigned.txt
+++ b/testcases/display/ansi_port_output_net_unsigned.txt
@@ -52,7 +52,7 @@ Module:
     DataType: String
     ClassIdentifier: None
     NetType: Wire
-    Signedness: Unsigned
+    Signedness: None
     PackedDimensions: []
     UnpackedDimensions: []
 

--- a/testcases/display/ansi_port_output_var_unsigned.txt
+++ b/testcases/display/ansi_port_output_var_unsigned.txt
@@ -63,7 +63,7 @@ Module:
     DataType: String
     ClassIdentifier: None
     NetType: None
-    Signedness: Unsigned
+    Signedness: None
     PackedDimensions: []
     UnpackedDimensions: []
 

--- a/testcases/display/ieee1800_2017_mh1.txt
+++ b/testcases/display/ieee1800_2017_mh1.txt
@@ -8,7 +8,7 @@ Module:
     DataType: Integer
     ClassIdentifier: None
     NetType: Wire
-    Signedness: Unsigned
+    Signedness: Signed
     PackedDimensions: []
     UnpackedDimensions: []
 

--- a/testcases/display/ieee1800_2017_mh10.txt
+++ b/testcases/display/ieee1800_2017_mh10.txt
@@ -8,7 +8,7 @@ Module:
     DataType: Integer
     ClassIdentifier: None
     NetType: None
-    Signedness: Unsigned
+    Signedness: Signed
     PackedDimensions: []
     UnpackedDimensions: []
 

--- a/testcases/display/ieee1800_2017_mh14.txt
+++ b/testcases/display/ieee1800_2017_mh14.txt
@@ -8,7 +8,7 @@ Module:
     DataType: Integer
     ClassIdentifier: None
     NetType: Wire
-    Signedness: Unsigned
+    Signedness: Signed
     PackedDimensions: []
     UnpackedDimensions: []
 

--- a/testcases/display/ieee1800_2017_mh16.txt
+++ b/testcases/display/ieee1800_2017_mh16.txt
@@ -8,7 +8,7 @@ Module:
     DataType: Integer
     ClassIdentifier: None
     NetType: None
-    Signedness: Unsigned
+    Signedness: Signed
     PackedDimensions: []
     UnpackedDimensions: []
 

--- a/testcases/display/ieee1800_2017_mh18.txt
+++ b/testcases/display/ieee1800_2017_mh18.txt
@@ -19,7 +19,7 @@ Module:
     DataType: Integer
     ClassIdentifier: None
     NetType: None
-    Signedness: Unsigned
+    Signedness: Signed
     PackedDimensions: []
     UnpackedDimensions: []
 

--- a/testcases/display/ieee1800_2017_mh2.txt
+++ b/testcases/display/ieee1800_2017_mh2.txt
@@ -8,7 +8,7 @@ Module:
     DataType: Integer
     ClassIdentifier: None
     NetType: Wire
-    Signedness: Unsigned
+    Signedness: Signed
     PackedDimensions: []
     UnpackedDimensions: []
 

--- a/testcases/display/ieee1800_2017_mh6.txt
+++ b/testcases/display/ieee1800_2017_mh6.txt
@@ -8,7 +8,7 @@ Module:
     DataType: Integer
     ClassIdentifier: None
     NetType: None
-    Signedness: Unsigned
+    Signedness: Signed
     PackedDimensions: []
     UnpackedDimensions: []
 

--- a/testcases/json/ansi_port_inout_net_unsigned.json
+++ b/testcases/json/ansi_port_inout_net_unsigned.json
@@ -63,7 +63,7 @@
           "datatype": "Int",
           "classid": null,
           "nettype": "Wire",
-          "signedness": "Unsigned",
+          "signedness": "Signed",
           "packed_dimensions": [],
           "unpacked_dimensions": []
         },

--- a/testcases/json/ansi_port_inout_net_unsigned.json
+++ b/testcases/json/ansi_port_inout_net_unsigned.json
@@ -101,7 +101,7 @@
           "datatype": "String",
           "classid": null,
           "nettype": "Wire",
-          "signedness": "Unsigned",
+          "signedness": null,
           "packed_dimensions": [],
           "unpacked_dimensions": []
         },

--- a/testcases/json/ansi_port_input_net_unsigned.json
+++ b/testcases/json/ansi_port_input_net_unsigned.json
@@ -95,7 +95,7 @@
           "datatype": "String",
           "classid": null,
           "nettype": "Wire",
-          "signedness": "Unsigned",
+          "signedness": null,
           "packed_dimensions": [],
           "unpacked_dimensions": []
         },

--- a/testcases/json/ansi_port_input_var_unsigned.json
+++ b/testcases/json/ansi_port_input_var_unsigned.json
@@ -90,7 +90,7 @@
           "datatype": "String",
           "classid": null,
           "nettype": null,
-          "signedness": "Unsigned",
+          "signedness": null,
           "packed_dimensions": [],
           "unpacked_dimensions": []
         },

--- a/testcases/json/ansi_port_output_net_unsigned.json
+++ b/testcases/json/ansi_port_output_net_unsigned.json
@@ -79,7 +79,7 @@
           "datatype": "String",
           "classid": null,
           "nettype": "Wire",
-          "signedness": "Unsigned",
+          "signedness": null,
           "packed_dimensions": [],
           "unpacked_dimensions": []
         },

--- a/testcases/json/ansi_port_output_var_unsigned.json
+++ b/testcases/json/ansi_port_output_var_unsigned.json
@@ -90,7 +90,7 @@
           "datatype": "String",
           "classid": null,
           "nettype": null,
-          "signedness": "Unsigned",
+          "signedness": null,
           "packed_dimensions": [],
           "unpacked_dimensions": []
         },

--- a/testcases/json/ieee1800_2017_mh1.json
+++ b/testcases/json/ieee1800_2017_mh1.json
@@ -11,7 +11,7 @@
           "datatype": "Integer",
           "classid": null,
           "nettype": "Wire",
-          "signedness": "Unsigned",
+          "signedness": "Signed",
           "packed_dimensions": [],
           "unpacked_dimensions": []
         }

--- a/testcases/json/ieee1800_2017_mh10.json
+++ b/testcases/json/ieee1800_2017_mh10.json
@@ -11,7 +11,7 @@
           "datatype": "Integer",
           "classid": null,
           "nettype": null,
-          "signedness": "Unsigned",
+          "signedness": "Signed",
           "packed_dimensions": [],
           "unpacked_dimensions": []
         }

--- a/testcases/json/ieee1800_2017_mh14.json
+++ b/testcases/json/ieee1800_2017_mh14.json
@@ -11,7 +11,7 @@
           "datatype": "Integer",
           "classid": null,
           "nettype": "Wire",
-          "signedness": "Unsigned",
+          "signedness": "Signed",
           "packed_dimensions": [],
           "unpacked_dimensions": []
         },

--- a/testcases/json/ieee1800_2017_mh16.json
+++ b/testcases/json/ieee1800_2017_mh16.json
@@ -11,7 +11,7 @@
           "datatype": "Integer",
           "classid": null,
           "nettype": null,
-          "signedness": "Unsigned",
+          "signedness": "Signed",
           "packed_dimensions": [],
           "unpacked_dimensions": []
         },

--- a/testcases/json/ieee1800_2017_mh18.json
+++ b/testcases/json/ieee1800_2017_mh18.json
@@ -27,7 +27,7 @@
           "datatype": "Integer",
           "classid": null,
           "nettype": null,
-          "signedness": "Unsigned",
+          "signedness": "Signed",
           "packed_dimensions": [],
           "unpacked_dimensions": []
         }

--- a/testcases/json/ieee1800_2017_mh2.json
+++ b/testcases/json/ieee1800_2017_mh2.json
@@ -11,7 +11,7 @@
           "datatype": "Integer",
           "classid": null,
           "nettype": "Wire",
-          "signedness": "Unsigned",
+          "signedness": "Signed",
           "packed_dimensions": [],
           "unpacked_dimensions": []
         }

--- a/testcases/json/ieee1800_2017_mh6.json
+++ b/testcases/json/ieee1800_2017_mh6.json
@@ -11,7 +11,7 @@
           "datatype": "Integer",
           "classid": null,
           "nettype": null,
-          "signedness": "Unsigned",
+          "signedness": "Signed",
           "packed_dimensions": [],
           "unpacked_dimensions": []
         }

--- a/testcases/yaml/ansi_port_inout_net_unsigned.yaml
+++ b/testcases/yaml/ansi_port_inout_net_unsigned.yaml
@@ -73,7 +73,7 @@ modules:
         datatype: String
         classid: ~
         nettype: Wire
-        signedness: Unsigned
+        signedness: ~
         packed_dimensions: []
         unpacked_dimensions: []
       - identifier: h

--- a/testcases/yaml/ansi_port_inout_net_unsigned.yaml
+++ b/testcases/yaml/ansi_port_inout_net_unsigned.yaml
@@ -44,7 +44,7 @@ modules:
         datatype: Int
         classid: ~
         nettype: Wire
-        signedness: Unsigned
+        signedness: Signed
         packed_dimensions: []
         unpacked_dimensions: []
       - identifier: e

--- a/testcases/yaml/ansi_port_input_net_unsigned.yaml
+++ b/testcases/yaml/ansi_port_input_net_unsigned.yaml
@@ -66,7 +66,7 @@ modules:
         datatype: String
         classid: ~
         nettype: Wire
-        signedness: Unsigned
+        signedness: ~
         packed_dimensions: []
         unpacked_dimensions: []
       - identifier: g

--- a/testcases/yaml/ansi_port_input_var_unsigned.yaml
+++ b/testcases/yaml/ansi_port_input_var_unsigned.yaml
@@ -64,7 +64,7 @@ modules:
         datatype: String
         classid: ~
         nettype: ~
-        signedness: Unsigned
+        signedness: ~
         packed_dimensions: []
         unpacked_dimensions: []
       - identifier: g

--- a/testcases/yaml/ansi_port_output_net_unsigned.yaml
+++ b/testcases/yaml/ansi_port_output_net_unsigned.yaml
@@ -55,7 +55,7 @@ modules:
         datatype: String
         classid: ~
         nettype: Wire
-        signedness: Unsigned
+        signedness: ~
         packed_dimensions: []
         unpacked_dimensions: []
       - identifier: f

--- a/testcases/yaml/ansi_port_output_var_unsigned.yaml
+++ b/testcases/yaml/ansi_port_output_var_unsigned.yaml
@@ -64,7 +64,7 @@ modules:
         datatype: String
         classid: ~
         nettype: ~
-        signedness: Unsigned
+        signedness: ~
         packed_dimensions: []
         unpacked_dimensions: []
       - identifier: g

--- a/testcases/yaml/ieee1800_2017_mh1.yaml
+++ b/testcases/yaml/ieee1800_2017_mh1.yaml
@@ -9,7 +9,7 @@ modules:
         datatype: Integer
         classid: ~
         nettype: Wire
-        signedness: Unsigned
+        signedness: Signed
         packed_dimensions: []
         unpacked_dimensions: []
     filepath: testcases/sv/ieee1800_2017_mh1.sv

--- a/testcases/yaml/ieee1800_2017_mh10.yaml
+++ b/testcases/yaml/ieee1800_2017_mh10.yaml
@@ -9,7 +9,7 @@ modules:
         datatype: Integer
         classid: ~
         nettype: ~
-        signedness: Unsigned
+        signedness: Signed
         packed_dimensions: []
         unpacked_dimensions: []
     filepath: testcases/sv/ieee1800_2017_mh10.sv

--- a/testcases/yaml/ieee1800_2017_mh14.yaml
+++ b/testcases/yaml/ieee1800_2017_mh14.yaml
@@ -9,7 +9,7 @@ modules:
         datatype: Integer
         classid: ~
         nettype: Wire
-        signedness: Unsigned
+        signedness: Signed
         packed_dimensions: []
         unpacked_dimensions: []
       - identifier: y

--- a/testcases/yaml/ieee1800_2017_mh16.yaml
+++ b/testcases/yaml/ieee1800_2017_mh16.yaml
@@ -9,7 +9,7 @@ modules:
         datatype: Integer
         classid: ~
         nettype: ~
-        signedness: Unsigned
+        signedness: Signed
         packed_dimensions: []
         unpacked_dimensions: []
       - identifier: y

--- a/testcases/yaml/ieee1800_2017_mh18.yaml
+++ b/testcases/yaml/ieee1800_2017_mh18.yaml
@@ -20,7 +20,7 @@ modules:
         datatype: Integer
         classid: ~
         nettype: ~
-        signedness: Unsigned
+        signedness: Signed
         packed_dimensions: []
         unpacked_dimensions: []
     filepath: testcases/sv/ieee1800_2017_mh18.sv

--- a/testcases/yaml/ieee1800_2017_mh2.yaml
+++ b/testcases/yaml/ieee1800_2017_mh2.yaml
@@ -9,7 +9,7 @@ modules:
         datatype: Integer
         classid: ~
         nettype: Wire
-        signedness: Unsigned
+        signedness: Signed
         packed_dimensions: []
         unpacked_dimensions: []
     filepath: testcases/sv/ieee1800_2017_mh2.sv

--- a/testcases/yaml/ieee1800_2017_mh6.yaml
+++ b/testcases/yaml/ieee1800_2017_mh6.yaml
@@ -9,7 +9,7 @@ modules:
         datatype: Integer
         classid: ~
         nettype: ~
-        signedness: Unsigned
+        signedness: Signed
         packed_dimensions: []
         unpacked_dimensions: []
     filepath: testcases/sv/ieee1800_2017_mh6.sv


### PR DESCRIPTION
The default signedness for shortint, int, longint, byte, integer was changed from unsigned to signed.